### PR TITLE
adds db_port to database connection

### DIFF
--- a/upload/index.php
+++ b/upload/index.php
@@ -28,7 +28,7 @@ $config = new Config();
 $registry->set('config', $config);
 
 // Database
-$db = new DB(DB_DRIVER, DB_HOSTNAME, DB_USERNAME, DB_PASSWORD, DB_DATABASE);
+$db = new DB(DB_DRIVER, DB_HOSTNAME, DB_USERNAME, DB_PASSWORD, DB_DATABASE, DB_PORT);
 $registry->set('db', $db);
 
 // Store


### PR DESCRIPTION
If you have to start new connection with different port (not 3306), index.php does not create connection and tells you that database user password is not correct, so it is a bit difficult to figure out what is going on, if you do not know exactly where to find the problem.